### PR TITLE
Disable pre-commit hook

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -27,6 +27,8 @@ jobs:
       run: |
         git config --global user.name "AlexUpBot"
         git config --global user.email "alexupbot@bot.com"
+    - name: Disable pre-commit hooks
+      run: export HUSKY=0
     - name: Update dependencies
       run: |
         cp package-lock.json package-lock-backup.json


### PR DESCRIPTION
In the update-dependencies script, do not run pre-commit hooks since that will make the pull request creation fail if it fails. We should instead be checking the things the pre-commits check in the CI scripts of the pull request itself.