### PR TITLE
Remove workflow_dispatch from update-dependencies script

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,6 +1,5 @@
 name: Update Dependencies
-on: 
-  workflow_dispatch:
+on:
   schedule:
   - cron: 0 0 * * 6
 


### PR DESCRIPTION
If dependencies need updating any other time, it's probably better to just do it in your own pull request so you can deal with any issues that may arise more directly.