### PR TITLE
Add scripts to switch between local and live versions of components p…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,10 +87,13 @@
       }
     },
     "node_modules/@alextheman/utility": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@alextheman/utility/-/utility-1.11.3.tgz",
-      "integrity": "sha512-CRvYoTk5GGmVs4Gr/oRPhiICEm0z745GSleuim3gzPVuPYby37FgccxV6woAoUw+fMRdh9oQAef7+zBYbf2CAA==",
-      "license": "ISC"
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/@alextheman/utility/-/utility-1.16.0.tgz",
+      "integrity": "sha512-80C2+UVpWVHs27r/n/GIbsr/wiJN9+rcGuEzreohDe7oFvkLQvn8dHo7QHkDKUjXQ0HylE7kIuWx3C9sS9DCcw==",
+      "license": "ISC",
+      "dependencies": {
+        "zod": "^4.1.5"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -9953,6 +9956,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.5.tgz",
+      "integrity": "sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "lint": "tsc --noEmit && eslint 'src/**/*.{ts,tsx}' && prettier --check --parser typescript 'src/**/*.{ts,tsx}'",
     "preview": "vite preview",
     "prepare": "husky",
-    "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --"
+    "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",
+    "use-local-components": "npm --prefix ../components run create-local-package && npm uninstall @alextheman/components && npm install ../components/alextheman-components-*.tgz",
+    "use-live-components": "npm uninstall @alextheman/components && npm install @alextheman/components"
   },
   "dependencies": {
     "@alextheman/components": "^3.5.3",


### PR DESCRIPTION
…ackage

It's often useful when developing components to be able to test it out in the actual repository we're working in before it gets published. The most common way is probably to to do npm install ../components, but that doesn't often work well since the dependencies don't really resolve properly, meaning that the theme often looks broken when developing locally.

To get around this, we now generate a .tgz file using npm pack, which is what actually gets used when the package gets published, so we can just install that instead. To help make this easier to develop with, I have set up a few scripts in package.json to help us easily switch between the two without too much thought.