### PR TITLE
Add check for local file dependencies to lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "dev": "vite",
     "format": "prettier --write --parser typescript \"src/**/*.{ts,tsx}\" && eslint --fix --suppress-all \"src/**/*.{ts,tsx}\" \"package.json\" && rm -f eslint-suppressions.json",
-    "lint": "tsc --noEmit && eslint \"src/**/*.{ts,tsx}\" \"package.json\" && prettier --check --parser typescript \"src/**/*.{ts,tsx}\"",
+    "lint": "tsc --noEmit && eslint \"src/**/*.{ts,tsx}\" \"package.json\" && npx alex-c-line check-for-file-dependencies && prettier --check --parser typescript \"src/**/*.{ts,tsx}\"",
     "prepare": "husky",
     "preview": "vite preview",
     "update-dependencies": "bash -c 'npx npm-check-updates -u \"$@\" && npm install' --",


### PR DESCRIPTION
This ensures that we don't have a leftover file dependency when switching between local components and live components before pushing.